### PR TITLE
chore: setup rebase automation

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,19 @@
+# .github/workflows/sync.yml
+name: Rebase Upstream
+on:
+  schedule:
+  - cron: "0 0 * * 0"  # run once a week
+  workflow_dispatch:   # run manually
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0 # fetching all history so i can rebase
+        token: ${{ secrets.GH_TOKEN }}
+    - uses: tradeshift/rebase-upstream-action@master
+      # with:  # all args are optional
+      #   upstream: <user>/<repo>
+      #   branch:   master


### PR DESCRIPTION
Motivation: we want to get upstream changes automatically because they usually fix vulnerabilities